### PR TITLE
Correction on handling invalid username on API call

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,13 @@
 class UsersController < ApplicationController
   def create
     username = params[:username].strip
-    raise "Username can't be blank" if username.blank?
-    raise 'Invalid GitHub username format' unless username =~ /\A[-a-zA-Z0-9][a-zA-Z0-9_-]*\z/
+    # First, validate username name spelling.
+    # Then, check if it exists in GitHub.
+    validate_username_format(username)
+    check_github_username_exists(username)
 
+    # If the user exists in the DB, find it and update the repos.
+    # If it doesn't, create it and it's repos.
     user = User.find_or_create_by!(username: username)
     FetchGithubReposJob.perform_async(user.username)
 
@@ -11,5 +15,22 @@ class UsersController < ApplicationController
   rescue StandardError => e
     Rails.logger.error("Error creating user #{username}: #{e.message}")
     render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def validate_username_format(username)
+    raise "Username can't be blank" if username.blank?
+    raise 'Invalid GitHub username format' unless username =~ /\A[-a-zA-Z0-9][a-zA-Z0-9_-]*\z/
+  end
+
+  def check_github_username_exists(username)
+    response = HTTParty.get("https://api.github.com/users/#{username}")
+
+    if response.code == 404
+      raise "GitHub username '#{username}' not found"
+    elsif response.code != 200
+      raise "Failed to validate GitHub username (status code: #{response.code})"
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,13 +3,19 @@ require 'rails_helper'
 RSpec.describe UsersController, type: :controller do
   describe 'POST #create' do
     let(:valid_username) { 'valid-username' }
-    let(:invalid_username) { 'invalid username' }
+    let(:invalid_username_format) { 'invalid username' }
+    let(:nonexistent_username) { 'nonexistent-username' }
 
     before do
       allow(FetchGithubReposJob).to receive(:perform_async)
+      allow(HTTParty).to receive(:get).and_return(double('response', code: 200))
     end
 
     context 'with valid username' do
+      before do
+        allow(HTTParty).to receive(:get).with("https://api.github.com/users/#{valid_username}").and_return(double('response', code: 200))
+      end
+
       it 'creates a user if it does not exist' do
         expect {
           post :create, params: { username: valid_username }
@@ -35,7 +41,7 @@ RSpec.describe UsersController, type: :controller do
       end
     end
 
-    context 'with invalid username' do
+    context 'with invalid username format' do
       it 'raises an error if username is blank' do
         post :create, params: { username: '' }
         expect(response).to have_http_status(:unprocessable_entity)
@@ -43,13 +49,29 @@ RSpec.describe UsersController, type: :controller do
       end
 
       it 'raises an error if username format is invalid' do
-        post :create, params: { username: invalid_username }
+        post :create, params: { username: invalid_username_format }
         expect(response).to have_http_status(:unprocessable_entity)
         expect(JSON.parse(response.body)['error']).to eq('Invalid GitHub username format')
       end
     end
 
+    context 'when GitHub username does not exist' do
+      before do
+        allow(HTTParty).to receive(:get).with("https://api.github.com/users/#{nonexistent_username}").and_return(double('response', code: 404))
+      end
+
+      it 'raises an error if GitHub username is not found' do
+        post :create, params: { username: nonexistent_username }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['error']).to eq("GitHub username '#{nonexistent_username}' not found")
+      end
+    end
+
     context 'with unexpected error' do
+      before do
+        allow(HTTParty).to receive(:get).with("https://api.github.com/users/#{valid_username}").and_return(double('response', code: 200))
+      end
+
       it 'handles unexpected errors gracefully' do
         allow(User).to receive(:find_or_create_by!).and_raise(StandardError, 'Unexpected error')
         post :create, params: { username: valid_username }

--- a/spec/jobs/fetch_github_repos_job_spec.rb
+++ b/spec/jobs/fetch_github_repos_job_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe FetchGithubReposJob, type: :job do
       end
     end
 
-    context 'when user does not exist' do
-      it 'does nothing' do
-        expect { described_class.new.perform('nonexistent-username') }.not_to raise_error
-      end
-    end
-
     context 'when unexpected error occurs' do
       it 'logs the error' do
         allow(HTTParty).to receive(:get).and_raise(StandardError, 'Unexpected error')


### PR DESCRIPTION
These wasn't any error handling working when calling an invalid username. This PR correct this, so now when the API calls a name like 'iaushdhoiashdoiasd', the controller first checks if the username exists (by making another call to GitHub API).